### PR TITLE
from_tflow: remove carets at start of input names

### DIFF
--- a/gamma/convert.py
+++ b/gamma/convert.py
@@ -23,7 +23,7 @@ def from_tflow(graph_def):
     unwrap = lambda arg: tf.make_ndarray(arg.tensor) if arg.HasField('tensor') else MessageToDict(arg)
     graph = {n.name: ({'type': n.op, 'label': n.name, 'params':
                        {k: unwrap(v) for k, v in n.attr.items()}
-                       }, [i.split(':', 1)[0] for i in n.input])
+                       }, [i.split('^', 1)[-1].split(':', 1)[0] for i in n.input])
              for n in graph_def.node}
     return reindex(graph, {k: i for (i, k) in enumerate(graph.keys())})
 


### PR DESCRIPTION
TensorFlow sometimes has carets at the start of input names. Not sure why, but since the tensor index is stripped atm anyway, it seems unlikely to cause any more harm.