### PR TITLE
Fix strip_inputs

### DIFF
--- a/gamma/core.py
+++ b/gamma/core.py
@@ -88,7 +88,7 @@ def external_inputs(graph):
 
 
 def strip_inputs(graph):
-    return {n: (attr, [i for i in inputs if i not in graph.keys()])
+    return {n: (attr, [i for i in inputs if i in graph.keys()])
             for n, (attr, inputs) in graph.items()}
 
 


### PR DESCRIPTION
strip_inputs currently removes all inputs which _are_ in the graph. I presume the intention was the opposite, since there is `external_inputs` already?