### PR TITLE
Initialising constant with list sets size to None

### DIFF
--- a/examples/resnet_demo.ipynb
+++ b/examples/resnet_demo.ipynb
@@ -2940,7 +2940,7 @@
     "]\n",
     "\n",
     "state_dict = rename(state_dict, name_rules)\n",
-    "state = {n: (constant([v.data, tuple(v.size())]), []) for n, v in state_dict.items()}\n",
+    "state = {n: (constant(v.data, tuple(v.size())), []) for n, v in state_dict.items()}\n",
     "draw(state, direction='TB')"
    ]
   },


### PR DESCRIPTION
`constant` is a `NodeDef(type=Constant, params=Signature(value, size=None))`.

The notebook calls this with a list of `[torch.Tensor, tuple]` as follows:

```
state = {n: (constant([v.data, tuple(v.size())]), []) for n, v in state_dict.items()}
```

The NodeDef `__call__` implementation `bind`s this list to the `params` `value` leaving `size` to be set to None by the call to `apply_defaults`.

Removing the list causes the tensor to be correctly bound to `value` and `tuple` to be bound to `size` as expected.